### PR TITLE
Target non active envs

### DIFF
--- a/demo-assets/conda-env/env1.yml
+++ b/demo-assets/conda-env/env1.yml
@@ -4,5 +4,3 @@ channels:
 dependencies:
   - numpy=1.9
   - matplotlib
-  - pip:
-    - flask

--- a/dof/_src/data/local.py
+++ b/dof/_src/data/local.py
@@ -2,9 +2,10 @@ from pathlib import Path
 from typing import List
 import os
 import yaml
+import base64
 
 from dof._src.models import environment
-from dof._src.utils import get_name_from_prefix, ensure_dir
+from dof._src.utils import ensure_dir
 
 def default_data_dir() -> Path:
     dof_dir = os.environ.get("DOF_DIR", None)
@@ -24,7 +25,10 @@ class LocalData:
         ensure_dir(self.data_dir)
 
     def _get_env_dir(self, prefix: str):
-        name = get_name_from_prefix(prefix=prefix)
+        # Not stoked on this approach. But provides a mapping
+        # between a prefix path and folder in a way that doesn't
+        # get too long and remains unique
+        name = prefix.replace("/", "-")
         return f"{self.data_dir}/{name}"
 
     def delete_environment_checkpoint(self, prefix: str, uuid: str):

--- a/dof/_src/utils.py
+++ b/dof/_src/utils.py
@@ -7,11 +7,6 @@ def hash_string(s: str) -> str:
     return hashlib.sha256(s.encode("utf-8")).hexdigest()
 
 
-def get_name_from_prefix(prefix: str) -> str:
-    """This function assumes an environment name is the last word in a conda prefix"""
-    return prefix.split("/")[-1]
-
-
 def ensure_dir(s: str):
     """Recursively create a directory if it does not exist"""
     path = Path(s)

--- a/dof/cli/checkpoint.py
+++ b/dof/cli/checkpoint.py
@@ -53,9 +53,16 @@ def delete(
     rev: str = typer.Option(
         help="uuid of the revision to delete"
     ),
+     prefix: str = typer.Option(
+        None,
+        help="prefix to save"
+    ),
 ):
     """Delete a previous revision of the environment"""
-    prefix = os.environ.get("CONDA_PREFIX")
+    if prefix is None:
+        prefix = os.environ.get("CONDA_PREFIX")
+    else:
+        prefix = os.path.abspath(prefix)
     data = LocalData()
     data.delete_environment_checkpoint(prefix=prefix, uuid=rev)
 
@@ -95,9 +102,16 @@ def install(
     rev: str = typer.Option(
         help="uuid of the revision to install"
     ),
+    prefix: str = typer.Option(
+        None,
+        help="prefix to save"
+    ),
 ):
     """Install a previous revision of the environment"""
-    prefix = os.environ.get("CONDA_PREFIX")
+    if prefix is None:
+        prefix = os.environ.get("CONDA_PREFIX")
+    else:
+        prefix = os.path.abspath(prefix)
     env_uuid = short_uuid()
     chck = Checkpoint.from_prefix(prefix=prefix, uuid=env_uuid)
     packages_in_current_not_in_target, packages_in_target_not_in_current = chck.diff(rev)
@@ -118,9 +132,16 @@ def diff(
     rev: str = typer.Option(
         help="uuid of the revision to diff against"
     ),
+    prefix: str = typer.Option(
+        None,
+        help="prefix to save"
+    ),
 ):
     """Generate a diff of the current environment to the specified revision"""
-    prefix = os.environ.get("CONDA_PREFIX")
+    if prefix is None:
+        prefix = os.environ.get("CONDA_PREFIX")
+    else:
+        prefix = os.path.abspath(prefix)
     env_uuid = short_uuid()
     chck = Checkpoint.from_prefix(prefix=prefix, uuid=env_uuid)
     packages_in_current_not_in_target, packages_in_target_not_in_current = chck.diff(rev)
@@ -137,9 +158,16 @@ def show(
     rev: str = typer.Option(
         help="uuid of the revision to list packages for"
     ),
+    prefix: str = typer.Option(
+        None,
+        help="prefix to save"
+    ),
 ):
     """Generate a list packages in an environment revision"""
-    prefix = os.environ.get("CONDA_PREFIX")
+    if prefix is None:
+        prefix = os.environ.get("CONDA_PREFIX")
+    else:
+        prefix = os.path.abspath(prefix)
     chck = Checkpoint.from_uuid(prefix=prefix, uuid=rev)
     for pkg in chck.list_packages():
         print(pkg)

--- a/dof/cli/checkpoint.py
+++ b/dof/cli/checkpoint.py
@@ -25,12 +25,20 @@ def save(
         None,
         help="tags for the checkpoint"
     ),
+    prefix: str = typer.Option(
+        None,
+        help="prefix to save"
+    ),
 ):
-    """Create a lockfile for the current env and set a checkpoint.
+    """Create a checkpoint for the current state of an environemnt.
     
-    Assumes that the user is currently in a conda environment
+    If no prefix is specified, assumes the current conda environment.
     """
-    prefix = os.environ.get("CONDA_PREFIX")
+    if prefix is None:
+        prefix = os.environ.get("CONDA_PREFIX")
+    else:
+        prefix = os.path.abspath(prefix)
+    
     env_uuid = short_uuid()
     if tags is None:
         tags = [env_uuid]
@@ -55,10 +63,18 @@ def delete(
 @checkpoint_command.command()
 def list(
     ctx: typer.Context,
+    prefix: str = typer.Option(
+        None,
+        help="prefix to save"
+    ),
 ):
     """List all checkpoints for the current environment"""
     data = LocalData()
-    prefix = os.environ.get("CONDA_PREFIX")
+    if prefix is None:
+        prefix = os.environ.get("CONDA_PREFIX")
+    else:
+        prefix = os.path.abspath(prefix)
+    
     checkpoints = data.get_environment_checkpoints(prefix=prefix)
     checkpoints.sort(key=lambda x: x.timestamp, reverse=True)
 

--- a/dof/cli/checkpoint.py
+++ b/dof/cli/checkpoint.py
@@ -1,6 +1,7 @@
 import os
 import typer
 from typing import List
+import asyncio
 
 from rich.table import Table
 import rich
@@ -116,6 +117,8 @@ def install(
     chck = Checkpoint.from_prefix(prefix=prefix, uuid=env_uuid)
     packages_in_current_not_in_target, packages_in_target_not_in_current = chck.diff(rev)
 
+    print("!!!WARNING!!! This probably won't work if you have pip packages installed in your target prefix")
+
     print("packages to delete")
     for pkg in packages_in_current_not_in_target:
         print(f"- {pkg}")
@@ -123,7 +126,7 @@ def install(
     for pkg in packages_in_target_not_in_current:
         print(f"+ {pkg}")
 
-    print("Opps, I actually don't know how to install. Skipping for now!")
+    asyncio.run(chck.install())
 
 
 @checkpoint_command.command()

--- a/dof/cli/root.py
+++ b/dof/cli/root.py
@@ -54,7 +54,10 @@ def push(
     rev: str = typer.Option(
         help="uuid of the revision to push"
     ),
-
+    prefix: str = typer.Option(
+        None,
+        help="prefix to save"
+    ),
 ):
     """Push a checkpoint to a target"""
     park_url = os.environ.get("PARK_URL")
@@ -65,7 +68,11 @@ def push(
     environment = env_tag.split(":")[0]
     tag = env_tag.split(":")[1]
 
-    prefix = os.environ.get("CONDA_PREFIX")
+    if prefix is None:
+        prefix = os.environ.get("CONDA_PREFIX")
+    else:
+        prefix = os.path.abspath(prefix)
+
     chck = Checkpoint.from_uuid(prefix=prefix, uuid=rev)
     data = chck.env_checkpoint.model_dump()
 
@@ -78,7 +85,10 @@ def pull(
         "--target", "-t",
         help="namespace/environment:tag to push to"
     )],
-
+    prefix: str = typer.Option(
+        None,
+        help="prefix to save"
+    ),
 ):
     """Push a checkpoint to a target"""
     park_url = os.environ.get("PARK_URL")
@@ -91,6 +101,10 @@ def pull(
 
     checkpoint_data = api.pull(namespace, environment, tag)
 
-    prefix = os.environ.get("CONDA_PREFIX")
+    if prefix is None:
+        prefix = os.environ.get("CONDA_PREFIX")
+    else:
+        prefix = os.path.abspath(prefix)
+
     chck = Checkpoint.from_checkpoint_dict(checkpoint_data=checkpoint_data, prefix=prefix)
     chck.save()


### PR DESCRIPTION
This PR adds the ability for users to specify a prefix to target when running dof commands. So, the user is not restricted to only running dof against the current active environment.

For example, to make a checkpoint for an environment that is not currently active, try
```
$  dof checkpoint save --prefix ./demo-assets/pixi-py/.pixi/envs/default/ --tags pixi-py   

$ dof checkpoint list --prefix ./demo-assets/pixi-py/.pixi/envs/default/ 
                         Checkpoints                          
┏━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ uuid     ┃ tags         ┃ timestamp                        ┃
┡━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ 9dcec2b0 │ ['9dcec2b0'] │ 2025-02-19 20:30:11.178100+00:00 │
│ f02a946c │ ['f02a946c'] │ 2025-02-19 20:23:52.572548+00:00 │
└──────────┴──────────────┴──────────────────────────────────┘
```

Calling out there is some clunky-ness around this UX. We'll want to look into a better way to allow users to specify running against non-active environments if that's a thing we really want to support.