### PR TITLE
Install pure conda environments

### DIFF
--- a/demo-assets/conda-env/env1.yml
+++ b/demo-assets/conda-env/env1.yml
@@ -4,4 +4,3 @@ channels:
 dependencies:
   - python>=3.10
   - numpy=2.1
-  - pip

--- a/demo-assets/conda-env/env1.yml
+++ b/demo-assets/conda-env/env1.yml
@@ -2,5 +2,6 @@ name: env1
 channels:
   - conda-forge
 dependencies:
-  - numpy=1.9
-  - matplotlib
+  - python>=3.10
+  - numpy=2.1
+  - pip

--- a/dof/_src/checkpoint.py
+++ b/dof/_src/checkpoint.py
@@ -5,6 +5,7 @@ import os
 from conda.core.prefix_data import PrefixData
 from rattler import Platform, PrefixRecord
 from rattler import install as rattler_install
+from rattler import solve as rattler_solve
 
 from dof._src.models import package, environment
 from dof._src.utils import hash_string
@@ -98,6 +99,13 @@ class Checkpoint():
         # WARNING: DOES NOT WORK FOR PIP OR IF YOU HAVE PIP PACKAGES IN YOUR ENV
         repodata_records = [pkg.to_repodata_record() for pkg in self.env_checkpoint.environment.packages]
         repodata_records = [pkg for pkg in repodata_records if pkg is not None]
+        
+        python_package = [pkg for pkg in repodata_records if pkg.name == "python"]
+        pip = [pkg for pkg in repodata_records if pkg.name == "python"]
+
+        # repodata_records = [pkg for pkg in repodata_records if pkg.name != "wheel" and pkg.name != "pip" and pkg.name != "python"]
+        repodata_records.sort(key=lambda x: str(x.name))
+        # repodata_records.append(python_package[0])
 
         prefix_records = []
         meta_path = f"{self.prefix}/conda-meta"
@@ -114,9 +122,21 @@ class Checkpoint():
         else:
             prefix_records = None
 
+        # solved_records = await rattler_solve(
+        #     # Channels to use for solving
+        #     channels=["conda-forge"],
+        #     # The specs to solve for
+        #     specs=["python", "pip", "numpy"],
+        # )
+        # solved_np = [pkg for pkg in solved_records if pkg.name == "numpy"][0]
+        # my_np = [pkg for pkg in repodata_records if pkg.name == "numpy"][0]
+
+        # import pdb; pdb.set_trace()
+
         await rattler_install(
             repodata_records,
             target_prefix=self.prefix,
             installed_packages=prefix_records,
-            execute_link_scripts=True
+            execute_link_scripts=True,
+            platform=Platform("linux-64"),
         )

--- a/dof/_src/checkpoint.py
+++ b/dof/_src/checkpoint.py
@@ -1,5 +1,6 @@
 from typing import List, Dict
 import datetime
+import os
 
 from conda.core.prefix_data import PrefixData
 from rattler import Platform
@@ -102,3 +103,11 @@ class Checkpoint():
             target_prefix=self.prefix,
             execute_link_scripts=True,
         )
+        # ensure that the history file exists. This let's conda know that it's a real 
+        # environment. If it doesn't exist, create it
+        history_file = f"{self.prefix}/conda-meta/history"
+        if not os.path.isfile(history_file):
+            with open(history_file, "w") as f:
+                f.write("# history file created with dof")
+
+

--- a/dof/_src/models/package.py
+++ b/dof/_src/models/package.py
@@ -15,8 +15,16 @@ class CondaPackage(BaseModel):
     platform: str
     url: str
 
+    def __str__(self):
+        return f"conda: {self.name} - {self.version}"
+    
+    def __eq__(self, other):
+        if isinstance(other, CondaPackage):
+            return self.url == other.url
+        return False
+
     def to_repodata_record(self):
-        """Converts a url package into a rattler compatible repodata record."""
+        """Converts a conda package into a rattler compatible repodata record."""
         pkg_record = PackageRecord(
              name=self.name, version=self.version, build=self.build,
              build_number=self.build_number, subdir=self.subdir, arch=None,
@@ -30,15 +38,6 @@ class CondaPackage(BaseModel):
         )
         
 
-    def __str__(self):
-        return f"conda: {self.name} - {self.version}"
-    
-    def __eq__(self, other):
-        if isinstance(other, CondaPackage):
-            return self.url == other.url
-        return False
-
-
 class PipPackage(BaseModel):
     name: str
     version: str
@@ -47,14 +46,14 @@ class PipPackage(BaseModel):
 
     def __str__(self):
         return f"pip: {self.name} - {self.version}"
-    
+
     def __eq__(self, other):
         if isinstance(other, PipPackage):
             return self.name == other.name and self.version == other.version and self.build == other.build
         return False
     
     def to_repodata_record(self):
-        """Converts a url package into a rattler compatible repodata record."""
+        """Converts a pip package into a rattler compatible repodata record."""
         # no-op
         pass
 

--- a/dof/cli/checkpoint.py
+++ b/dof/cli/checkpoint.py
@@ -126,7 +126,8 @@ def install(
     for pkg in packages_in_target_not_in_current:
         print(f"+ {pkg}")
 
-    asyncio.run(chck.install())
+    rev_checkpoint = Checkpoint.from_uuid(prefix=prefix, uuid=rev)
+    asyncio.run(rev_checkpoint.install_with_rattler())
 
 
 @checkpoint_command.command()
@@ -159,6 +160,7 @@ def diff(
 def show(
     ctx: typer.Context,
     rev: str = typer.Option(
+        None,
         help="uuid of the revision to list packages for"
     ),
     prefix: str = typer.Option(
@@ -171,6 +173,12 @@ def show(
         prefix = os.environ.get("CONDA_PREFIX")
     else:
         prefix = os.path.abspath(prefix)
-    chck = Checkpoint.from_uuid(prefix=prefix, uuid=rev)
+
+    if rev is None:
+        env_uuid = short_uuid()
+        chck = Checkpoint.from_prefix(prefix=prefix, uuid=env_uuid)
+    else:
+        chck = Checkpoint.from_uuid(prefix=prefix, uuid=rev)
+
     for pkg in chck.list_packages():
         print(pkg)


### PR DESCRIPTION
This pr hooks up the `install` cli option. It only works if you have an environment with only conda packages in it. 

For example, try it out with the included `demo-assets/conda-env/env1.yml`:

## Roll back to an old environment

```
# create the env
$ conda env create -f demo-assets/conda-env/env1.yml`

# save the checkpoint
$ dof checkpoint save --prefix ~/miniconda3/envs/env1
$ dof checkpoint list --prefix ~/miniconda3/envs/env1 
                         Checkpoints                          
┏━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ uuid     ┃ tags         ┃ timestamp                        ┃
┡━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ f67d5e7a │ ['f67d5e7a'] │ 2025-02-20 23:46:57.098607+00:00 │
└──────────┴──────────────┴──────────────────────────────────┘

# install a new package - try out importing flask in that environment to verify that it is installed
$ conda install flask -p ~/miniconda3/envs/env1

# create a new checkpoint
$ dof checkpoint save --prefix ~/miniconda3/envs/env1  
dof checkpoint list --prefix ~/miniconda3/envs/env1    
                         Checkpoints                          
┏━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ uuid     ┃ tags         ┃ timestamp                        ┃
┡━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ 9db5e40b │ ['9db5e40b'] │ 2025-02-20 23:49:35.665817+00:00 │
│ f67d5e7a │ ['f67d5e7a'] │ 2025-02-20 23:46:57.098607+00:00 │
└──────────┴──────────────┴──────────────────────────────────┘

# see the difference between the current env and the first checkpoint
$ dof checkpoint diff --rev f67d5e7a --prefix ~/miniconda3/envs/env1
diff with rev f67d5e7a
+ conda: blinker - 1.9.0
+ conda: click - 8.1.8
+ conda: itsdangerous - 2.2.0
+ conda: markupsafe - 3.0.2
+ conda: zipp - 3.21.0
+ conda: importlib-metadata - 8.6.1
+ conda: jinja2 - 3.1.5
+ conda: werkzeug - 3.1.3
+ conda: flask - 3.1.0

# install the first checkpoint
$ dof checkpoint install --rev f67d5e7a --prefix ~/miniconda3/envs/env1
!!!WARNING!!! This probably won't work if you have pip packages installed in your target prefix
packages to delete
- conda: blinker - 1.9.0
- conda: click - 8.1.8
- conda: itsdangerous - 2.2.0
- conda: markupsafe - 3.0.2
- conda: zipp - 3.21.0
- conda: importlib-metadata - 8.6.1
- conda: jinja2 - 3.1.5
- conda: werkzeug - 3.1.3
- conda: flask - 3.1.0

packages to install
✔ validate cache       31 packages in 147ms
✔ download & extract   3 packages (49.26 KiB) in 133ms
✔ installing packages  took 201ms                                                                                            

# see that our new env matches the installed checkpoint -  try out importing flask in that environment to verify that it is not installed
$ dof checkpoint diff --rev f67d5e7a --prefix ~/miniconda3/envs/env1
diff with rev f67d5e7a
```

## Install a new environment from a checkpoint
```
# following the above example, delete the conda environment
$  conda env remove -n env1      

# still have the checkpoints from the env
$ dof checkpoint list --prefix ~/miniconda3/envs/env1 

# install one of the checkpoints
$ dof checkpoint install --rev f67d5e7a --prefix ~/miniconda3/envs/env1 

# see packages in the env
$ conda list -p ~/miniconda3/envs/env1  

# activate the env
$ conda activate ~/miniconda3/envs/env1 
```